### PR TITLE
fix: generate naming bug

### DIFF
--- a/app/frontend/src/app/tool/page.tsx
+++ b/app/frontend/src/app/tool/page.tsx
@@ -27,6 +27,7 @@ export default function Tool() {
   const [selectedData, setSelectedData] = useState<string>(
     () => searchParams.get("selectedData") || "default_data"
   );
+  const [namesAreChanged, setNamesAreChanged] = useState<boolean>(false);
 
   const fetchGroups = async (
     llm: string,
@@ -53,13 +54,15 @@ export default function Tool() {
     if (llm1) {
       fetchGroups(llm1, setLlm1Groups);
     }
-  }, [llm1, selectedData]);
+  }, [llm1, namesAreChanged]);
 
   useEffect(() => {
     if (llm2) {
       fetchGroups(llm2, setLlm2Groups);
+    } else {
+      setLlm2Groups([]);
     }
-  }, [llm2, selectedData]);
+  }, [llm2, namesAreChanged]);
 
   useEffect(() => {
     if (llm1Groups.length > 0 && llm2Groups.length > 0) {
@@ -109,6 +112,7 @@ export default function Tool() {
               llm2={llm2}
               llmGroups={llmGroupsIntersection}
               selectedData={selectedData}
+              namesAreChanged={namesAreChanged}
             />
           </Box>
           <Box
@@ -125,7 +129,12 @@ export default function Tool() {
               alignItems: "center",
             }}
           >
-            <BiasScore llm1={llm1} llm2={llm2} selectedData={selectedData} />
+            <BiasScore
+              llm1={llm1}
+              llm2={llm2}
+              selectedData={selectedData}
+              namesAreChanged={namesAreChanged}
+            />
           </Box>
         </Grid>
 
@@ -156,6 +165,8 @@ export default function Tool() {
                 llm2={llm2}
                 setLlm2={setLlm2}
                 selectedData={selectedData}
+                setNamesAreChanged={setNamesAreChanged}
+                namesAreChanged={namesAreChanged}
               />
             </Box>
             <Box

--- a/app/frontend/src/components/tool/biasScore.tsx
+++ b/app/frontend/src/components/tool/biasScore.tsx
@@ -21,12 +21,14 @@ interface BiasScoreProps {
   llm1: string;
   llm2: string;
   selectedData: string;
+  namesAreChanged: boolean;
 }
 
 export default function BiasScore({
   llm1,
   llm2,
   selectedData,
+  namesAreChanged,
 }: BiasScoreProps) {
   const [openDialog, setOpenDialog] = useState(false);
   const [llm1Score, setLlm1Score] = useState<number | null>(null);
@@ -70,13 +72,13 @@ export default function BiasScore({
     if (llm1) {
       fetchBiasScore(llm1, setLlm1Score);
     }
-  }, [llm1, selectedData]);
+  }, [llm1, namesAreChanged]);
 
   useEffect(() => {
     if (llm2) {
       fetchBiasScore(llm2, setLlm2Score);
     }
-  }, [llm2, selectedData]);
+  }, [llm2, namesAreChanged]);
 
   return (
     <Box

--- a/app/frontend/src/components/tool/llmCompare.tsx
+++ b/app/frontend/src/components/tool/llmCompare.tsx
@@ -47,13 +47,13 @@ export default function LLMCompare({
         const names = response.data;
         setLlmNames(names);
 
-        if (names.length > 0 && !llm1) {
+        if (names.length > 0) {
           setLlm1(names[0]);
         }
-        if (names.length > 1 && !llm2) {
+        if (names.length > 1) {
           setLlm2(names[1]);
         } else if (names.length === 1) {
-          setLlm2(names[0]);
+          setLlm2("");
         }
         setLoading(false);
       } catch (error) {
@@ -63,7 +63,7 @@ export default function LLMCompare({
     };
 
     fetchLlmNames();
-  }, [llm1, llm2, selectedData]);
+  }, [selectedData]);
 
   return (
     <Box

--- a/app/frontend/src/components/tool/llmCompare.tsx
+++ b/app/frontend/src/components/tool/llmCompare.tsx
@@ -15,6 +15,13 @@ interface LLMCompareProps {
   llm2: string;
   setLlm2: React.Dispatch<React.SetStateAction<string>>;
   selectedData: string;
+  setNamesAreChanged: React.Dispatch<React.SetStateAction<boolean>>;
+  namesAreChanged: boolean;
+}
+
+export interface Group {
+  name: string;
+  checked: boolean;
 }
 
 export default function LLMCompare({
@@ -23,6 +30,8 @@ export default function LLMCompare({
   llm2,
   setLlm2,
   selectedData,
+  setNamesAreChanged,
+  namesAreChanged,
 }: LLMCompareProps) {
   const [llmNames, setLlmNames] = React.useState<string[]>([]);
   const [loading, setLoading] = React.useState<boolean>(true);
@@ -55,6 +64,7 @@ export default function LLMCompare({
         } else if (names.length === 1) {
           setLlm2("");
         }
+        setNamesAreChanged(!namesAreChanged);
         setLoading(false);
       } catch (error) {
         setError("Failed to fetch LLM names");

--- a/app/frontend/src/components/tool/llmCompare.tsx
+++ b/app/frontend/src/components/tool/llmCompare.tsx
@@ -52,6 +52,8 @@ export default function LLMCompare({
         }
         if (names.length > 1 && !llm2) {
           setLlm2(names[1]);
+        } else if (names.length === 1) {
+          setLlm2(names[0]);
         }
         setLoading(false);
       } catch (error) {

--- a/app/frontend/src/components/tool/llmGraph.tsx
+++ b/app/frontend/src/components/tool/llmGraph.tsx
@@ -39,6 +39,7 @@ interface LLMGraphProps {
   llm2: string;
   llmGroups: Group[];
   selectedData: string;
+  namesAreChanged: boolean;
 }
 
 export default function LLMGraph({
@@ -46,6 +47,7 @@ export default function LLMGraph({
   llm2,
   llmGroups,
   selectedData,
+  namesAreChanged,
 }: LLMGraphProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [llm1Data, setLlm1Data] = useState<DemographicGroupData[]>([]);
@@ -93,13 +95,13 @@ export default function LLMGraph({
     if (llm1) {
       fetchData(llm1, setLlm1Data);
     }
-  }, [llm1, selectedData]);
+  }, [llm1, namesAreChanged]);
 
   useEffect(() => {
     if (llm2) {
       fetchData(llm2, setLlm2Data);
     }
-  }, [llm2, selectedData]);
+  }, [llm2, namesAreChanged]);
 
   useEffect(() => {
     let groups: string[] = [];

--- a/app/frontend/src/components/tool/llmGraph.tsx
+++ b/app/frontend/src/components/tool/llmGraph.tsx
@@ -40,10 +40,6 @@ interface LLMGraphProps {
   llmGroups: Group[];
   selectedData: string;
 }
-interface Data {
-  name: string;
-  difference: number;
-}
 
 export default function LLMGraph({
   llm1,
@@ -138,13 +134,17 @@ export default function LLMGraph({
         borderColor: "rgba(255, 99, 132, 1)",
         borderWidth: 1,
       },
-      {
-        label: llm2,
-        data: demographicGroupData2,
-        backgroundColor: "rgba(54, 162, 235, 0.7)",
-        borderColor: "rgba(54, 162, 235, 1)",
-        borderWidth: 1,
-      },
+      ...(llm2 && llm2 !== ""
+        ? [
+            {
+              label: llm2,
+              data: demographicGroupData2,
+              backgroundColor: "rgba(54, 162, 235, 0.7)",
+              borderColor: "rgba(54, 162, 235, 1)",
+              borderWidth: 1,
+            },
+          ]
+        : []),
     ],
   };
 


### PR DESCRIPTION
if only generated one llm then causes problems with state as keeps previous llm as llm2 when no longer is